### PR TITLE
fix(db): enable sqlite_unicode for UTF-8 bucket names

### DIFF
--- a/Classifier/Bayes.pm
+++ b/Classifier/Bayes.pm
@@ -632,6 +632,7 @@ method db_connect {
     if ( $sqlite ) {
         $dbname = $self->get_user_path($self->config('database' ) );
         $dbpresent = ( -e $dbname ) || 0;
+        $connection_options{sqlite_unicode} = 1;
     } else {
         $dbname = $self->config('database' );
         $dbpresent = 1;


### PR DESCRIPTION
## Summary

- **Classifier/Bayes.pm**: Set `sqlite_unicode => 1` in DBI connection options for SQLite. Without this, DBD::SQLite returns text columns as raw byte strings; Mojolicious's JSON encoder then treats them as Latin-1 and re-encodes to UTF-8, causing double-encoding of non-ASCII characters (e.g. `persönliches` → `persÃ¶nliches`).

**Note:** existing databases with already-garbled bucket names will still display incorrectly — those bytes are what's stored. New buckets created after this fix will work correctly. Users with garbled names may need to rename them.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)