### PR TITLE
fix(ui): dark mode — replace hardcoded colors; bucket color dot

### DIFF
--- a/ui/src/lib/Corpus.svelte
+++ b/ui/src/lib/Corpus.svelte
@@ -85,7 +85,7 @@
     <tbody>
       {#each buckets as b (b.name)}
         <tr>
-          <td style="color:{b.color}; font-weight:600">{b.name}</td>
+          <td><span class="dot" style="background:{b.color}"></span>{b.name}</td>
           <td>{b.word_count ?? 0}</td>
           <td>
             <input
@@ -149,14 +149,15 @@
 
 <style>
   section { margin: 1.5rem 0; }
-  h3 { margin-bottom: 0.5rem; font-size: 1rem; color: #444; }
+  h3 { margin-bottom: 0.5rem; font-size: 1rem; color: var(--text-h); }
   table { border-collapse: collapse; width: 100%; }
-  th, td { padding: 0.4rem 0.7rem; border-bottom: 1px solid #e0e0e0; text-align: left; }
-  th { background: #f4f6fb; }
+  th, td { padding: 0.4rem 0.7rem; border-bottom: 1px solid var(--border); text-align: left; }
+  th { background: var(--code-bg); }
   .row { display: flex; gap: 0.5rem; align-items: center; }
-  input[type=text], select { padding: 0.35rem 0.6rem; border: 1px solid #ccc; border-radius: 4px; }
-  button { padding: 0.35rem 0.8rem; border: 1px solid #ccc; border-radius: 4px; cursor: pointer; }
+  input[type=text], select { padding: 0.35rem 0.6rem; border: 1px solid var(--border); border-radius: 4px; background: var(--bg); color: var(--text); }
+  button { padding: 0.35rem 0.8rem; border: 1px solid var(--border); border-radius: 4px; cursor: pointer; background: var(--bg); color: var(--text); }
   .btn-danger { color: #c0392b; border-color: #c0392b; }
   .status { color: #27ae60; font-weight: 500; }
   .word-list { column-count: 3; margin-top: 0.5rem; font-size: 0.85rem; }
+  .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 0.4rem; vertical-align: middle; }
 </style>

--- a/ui/src/lib/History.svelte
+++ b/ui/src/lib/History.svelte
@@ -63,8 +63,8 @@
           <td class="trunc">{item.from}</td>
           <td class="trunc">{item.subject}</td>
           <td>
-            <span class="bucket-badge" style="color:{item.color}">
-              {item.bucket}
+            <span class="bucket-badge">
+              <span class="dot" style="background:{item.color}"></span>{item.bucket}
             </span>
           </td>
           <td>
@@ -89,13 +89,14 @@
 
 <style>
   .toolbar { display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem; }
-  input[type=search] { padding: 0.4rem 0.6rem; border: 1px solid #ccc; border-radius: 4px; width: 280px; }
+  input[type=search] { padding: 0.4rem 0.6rem; border: 1px solid var(--border); border-radius: 4px; width: 280px; background: var(--bg); color: var(--text); }
   table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
-  th, td { padding: 0.4rem 0.6rem; border-bottom: 1px solid #e0e0e0; text-align: left; }
-  th { background: #f4f6fb; font-weight: 600; }
+  th, td { padding: 0.4rem 0.6rem; border-bottom: 1px solid var(--border); text-align: left; }
+  th { background: var(--code-bg); font-weight: 600; }
   .trunc { max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-  .bucket-badge { font-weight: 500; }
+  .bucket-badge { font-weight: 500; display: inline-flex; align-items: center; }
+  .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 0.4rem; flex-shrink: 0; }
   .pagination { display: flex; align-items: center; gap: 1rem; margin-top: 1rem; }
-  button { padding: 0.3rem 0.8rem; border: 1px solid #ccc; border-radius: 4px; cursor: pointer; }
+  button { padding: 0.3rem 0.8rem; border: 1px solid var(--border); border-radius: 4px; cursor: pointer; background: var(--bg); color: var(--text); }
   button:disabled { opacity: 0.4; cursor: default; }
 </style>


### PR DESCRIPTION
## Summary

- **Corpus.svelte** / **History.svelte**: replace all hardcoded colors (`#444`, `#e0e0e0`, `#f4f6fb`, `#ccc`) with CSS custom properties (`--text-h`, `--border`, `--code-bg`, `--bg`, `--text`) so dark mode works correctly
- Bucket names now render as plain text with a small colored dot instead of colored text — fixes readability when bucket color is dark

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)