### PR TITLE
feat(imap): fetch server folders; select-from-list; stale-mapping warning

### DIFF
--- a/UI/Mojo.pm
+++ b/UI/Mojo.pm
@@ -492,6 +492,27 @@ Injects the C<Services::Classifier> facade used by the child for REST calls.
         });
 
         #--------------------------------------------------------------------
+        # GET /api/v1/imap/server-folders
+        #   Connects to the IMAP server and returns the live folder list
+        #--------------------------------------------------------------------
+        $r->get( '/api/v1/imap/server-folders' => sub ($c) {
+            require Services::IMAP::Client;
+            my $client = Services::IMAP::Client->new();
+            $client->set_configuration($self->configuration());
+            $client->set_mq($self->mq());
+            $client->set_name('imap');
+            unless ($client->connect()) {
+                return $c->render(status => 503, json => { error => 'connect failed' });
+            }
+            unless ($client->login()) {
+                return $c->render(status => 503, json => { error => 'login failed' });
+            }
+            my @folders = $client->get_mailbox_list();
+            $client->logout();
+            $c->render(json => \@folders);
+        });
+
+        #--------------------------------------------------------------------
         # Start the daemon
         #--------------------------------------------------------------------
         my $daemon = Mojo::Server::Daemon->new(

--- a/ui/src/lib/IMAP.svelte
+++ b/ui/src/lib/IMAP.svelte
@@ -14,9 +14,12 @@
   let cfgStatus     = $state('');
   let foldersStatus = $state('');
   let newWatch      = $state('');
-  let newMapBucket  = $state('');
-  let newMapFolder  = $state('');
-  let saving        = $state(false);
+  let newMapBucket = $state('');
+  let newMapFolder = $state('');
+  let saving = $state(false);
+  let serverFolders = $state([]);
+  let fetchingFolders = $state(false);
+  let fetchError = $state('');
 
   let connectionReady = $derived(
     !!cfg.imap_hostname?.trim() &&
@@ -89,6 +92,18 @@
   function removeMapping(bucket) {
     mappings = mappings.filter(m => m.bucket !== bucket);
     foldersDirty = true;
+  }
+
+  async function fetchServerFolders() {
+    fetchingFolders = true;
+    fetchError = '';
+    const res = await fetch('/api/v1/imap/server-folders');
+    fetchingFolders = false;
+    if (res.ok) {
+      serverFolders = await res.json();
+    } else {
+      fetchError = 'Could not connect to server';
+    }
   }
 
   function markCfg() { cfgDirty = true; cfgStatus = ''; }
@@ -209,11 +224,18 @@
 
   <!-- ── Bucket → folder mappings ─────────────────────────────────────── -->
   <section class="card">
-    <h3>Bucket → Folder Mappings</h3>
+    <div class="section-header">
+      <h3>Bucket → Folder Mappings</h3>
+      <button class="btn btn-sm" onclick={fetchServerFolders}
+        disabled={!connectionReady || fetchingFolders}>
+        {fetchingFolders ? 'Fetching…' : 'Fetch Folders'}
+      </button>
+    </div>
     <p class="hint">
       Classified messages are moved to the specified IMAP folder.
       Leave unmapped buckets empty to skip moving.
     </p>
+    {#if fetchError}<p class="msg-err">{fetchError}</p>{/if}
 
     {#if mappings.length > 0}
       <table>
@@ -227,7 +249,12 @@
                 <span class="bucket-dot" style="background:{getBucketColor(m.bucket, buckets)}"></span>
                 {m.bucket}
               </td>
-              <td class="folder-cell">{m.folder}</td>
+              <td class="folder-cell">
+                {m.folder}
+                {#if serverFolders.length > 0 && !serverFolders.includes(m.folder)}
+                  <span class="warn" title="Folder not found on server">⚠</span>
+                {/if}
+              </td>
               <td>
                 <button class="btn-remove" onclick={() => removeMapping(m.bucket)} title="Remove">×</button>
               </td>
@@ -247,12 +274,21 @@
         {/each}
       </select>
       <span class="arrow">→</span>
-      <input
-        type="text"
-        placeholder="INBOX.Classified"
-        bind:value={newMapFolder}
-        onkeydown={(e) => e.key === 'Enter' && addMapping()}
-      />
+      {#if serverFolders.length > 0}
+        <select bind:value={newMapFolder}>
+          <option value="">— folder —</option>
+          {#each serverFolders as f}
+            <option value={f}>{f}</option>
+          {/each}
+        </select>
+      {:else}
+        <input
+          type="text"
+          placeholder="INBOX.Classified"
+          bind:value={newMapFolder}
+          onkeydown={(e) => e.key === 'Enter' && addMapping()}
+        />
+      {/if}
       <button class="btn" onclick={addMapping} disabled={!newMapBucket || !newMapFolder.trim()}>
         Add
       </button>
@@ -302,6 +338,10 @@
     margin-bottom: 1.25rem;
   }
   .card h3 { margin: 0 0 1rem; font-size: 1rem; font-weight: 600; color: var(--text); }
+  .section-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1rem; }
+  .section-header h3 { margin: 0; }
+  .btn-sm { padding: 0.25rem 0.65rem; font-size: 0.8rem; }
+  .warn { color: var(--danger); margin-left: 0.3rem; font-size: 0.85rem; cursor: default; }
   .hint { margin: -0.5rem 0 1rem; font-size: 0.8rem; color: var(--text-muted); }
 
   /* ── Field rows (inside cards) ── */


### PR DESCRIPTION
## Summary

- **UI/Mojo.pm**: new `GET /api/v1/imap/server-folders` endpoint — connects to the IMAP server, runs LIST, returns sorted folder names
- **IMAP.svelte**:
  - "Fetch Folders" button (disabled until connection settings are saved) calls the new endpoint
  - Bucket → Folder mapping input switches from free-text to a `<select>` once folders are fetched
  - Saved mappings referencing a folder absent from the server list show a ⚠ warning icon

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)