### PR TITLE
feat(ui): Status tab with IMAP health checks

### DIFF
--- a/UI/Mojo.pm
+++ b/UI/Mojo.pm
@@ -513,6 +513,88 @@ Injects the C<Services::Classifier> facade used by the child for REST calls.
         });
 
         #--------------------------------------------------------------------
+        # GET /api/v1/status
+        #   Returns health checks: IMAP connectivity, auth, watched folders,
+        #   bucket→folder mapping validity
+        #--------------------------------------------------------------------
+        $r->get( '/api/v1/status' => sub ($c) {
+            require Services::IMAP::Client;
+            my @checks;
+            my $hostname = $self->module_config('imap', 'hostname') // '';
+            my $port     = $self->module_config('imap', 'port')     // '';
+            my $login    = $self->module_config('imap', 'login')    // '';
+            unless ($hostname ne '' && $port ne '') {
+                push @checks, {
+                    id     => 'connectivity',
+                    label  => 'IMAP Connectivity',
+                    status => 'warn',
+                    detail => 'IMAP not configured',
+                };
+                return $c->render(json => { checks => \@checks });
+            }
+            my $client = Services::IMAP::Client->new();
+            $client->set_configuration($self->configuration());
+            $client->set_mq($self->mq());
+            $client->set_name('imap');
+            unless ($client->connect()) {
+                push @checks, {
+                    id     => 'connectivity',
+                    label  => 'IMAP Connectivity',
+                    status => 'error',
+                    detail => "Cannot reach $hostname:$port",
+                };
+                return $c->render(json => { checks => \@checks });
+            }
+            push @checks, {
+                id     => 'connectivity',
+                label  => 'IMAP Connectivity',
+                status => 'ok',
+                detail => "Connected to $hostname:$port",
+            };
+            unless ($client->login()) {
+                push @checks, {
+                    id     => 'authentication',
+                    label  => 'IMAP Authentication',
+                    status => 'error',
+                    detail => "Login failed for $login",
+                };
+                return $c->render(json => { checks => \@checks });
+            }
+            push @checks, {
+                id     => 'authentication',
+                label  => 'IMAP Authentication',
+                status => 'ok',
+                detail => "Logged in as $login",
+            };
+            my @server_folders = $client->get_mailbox_list();
+            $client->logout();
+            my %on_server = map { $_ => 1 } @server_folders;
+            my $watched_raw = $self->module_config('imap', 'watched_folders') // '';
+            my @watched     = grep { $_ ne '' } split /\Q$imap_sep\E/, $watched_raw;
+            my @missing_w   = grep { !$on_server{$_} } @watched;
+            push @checks, {
+                id     => 'watched_folders',
+                label  => 'Watched Folders',
+                status => @missing_w ? 'warn' : 'ok',
+                detail => @missing_w
+                    ? 'Missing on server: ' . join(', ', @missing_w)
+                    : 'All ' . scalar(@watched) . ' watched folder(s) exist',
+            };
+            my $mapping_raw = $self->module_config('imap', 'bucket_folder_mappings') // '';
+            my %map_hash    = split /\Q$imap_sep\E/, $mapping_raw;
+            my @missing_m   = grep { $_ ne '' && !$on_server{$map_hash{$_}} } keys %map_hash;
+            push @checks, {
+                id     => 'bucket_mappings',
+                label  => 'Bucket → Folder Mappings',
+                status => @missing_m ? 'warn' : 'ok',
+                detail => @missing_m
+                    ? 'Target folders missing: ' . join(', ', map { $map_hash{$_} } @missing_m)
+                    : 'All ' . scalar(keys %map_hash) . ' mapping(s) valid',
+            };
+            $c->render(json => { checks => \@checks });
+        });
+
+        #--------------------------------------------------------------------
         # Start the daemon
         #--------------------------------------------------------------------
         my $daemon = Mojo::Server::Daemon->new(

--- a/ui/src/App.svelte
+++ b/ui/src/App.svelte
@@ -5,6 +5,7 @@
   import IMAP     from './lib/IMAP.svelte';
   import Magnets  from './lib/Magnets.svelte';
   import Settings from './lib/Settings.svelte';
+  import Status   from './lib/Status.svelte';
 
   let page    = $state(window.location.hash.slice(1) || 'history');
   let buckets = $state([]);
@@ -28,6 +29,7 @@
     ['corpus',   'Corpus'],
     ['magnets',  'Magnets'],
     ['imap',     'IMAP'],
+    ['status',   'Status'],
     ['settings', 'Settings'],
   ];
 
@@ -57,6 +59,8 @@
     <Magnets {buckets} />
   {:else if page === 'imap'}
     <IMAP {buckets} />
+  {:else if page === 'status'}
+    <Status />
   {:else if page === 'settings'}
     <Settings />
   {/if}

--- a/ui/src/lib/Status.svelte
+++ b/ui/src/lib/Status.svelte
@@ -1,0 +1,153 @@
+<script>
+  import { onMount } from 'svelte';
+
+  let checks = $state([]);
+  let loading = $state(false);
+  let error = $state('');
+
+  async function load() {
+    loading = true;
+    error = '';
+    const res = await fetch('/api/v1/status');
+    loading = false;
+    if (res.ok) {
+      const data = await res.json();
+      checks = data.checks ?? [];
+    } else {
+      error = 'Failed to load status';
+    }
+  }
+
+  onMount(load);
+</script>
+
+<div class="page">
+  <div class="page-header">
+    <div>
+      <h2>Status</h2>
+      <p>Health checks for POPFile services.</p>
+    </div>
+    <button class="btn" onclick={load} disabled={loading}>
+      {loading ? 'Checking…' : 'Refresh'}
+    </button>
+  </div>
+
+  {#if error}
+    <p class="msg-err">{error}</p>
+  {/if}
+
+  <section class="card">
+    <h3>IMAP</h3>
+    {#if loading && checks.length === 0}
+      <p class="hint">Checking…</p>
+    {:else if checks.length === 0}
+      <p class="hint">No checks available.</p>
+    {:else}
+      <ul class="check-list">
+        {#each checks as check (check.id)}
+          <li class="check-row">
+            <span class="indicator {check.status}" title={check.status}></span>
+            <div class="check-body">
+              <span class="check-label">{check.label}</span>
+              <span class="check-detail">{check.detail}</span>
+            </div>
+            <span class="badge {check.status}">{check.status}</span>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </section>
+</div>
+
+<style>
+  .page {
+    padding: 1.75rem 2rem;
+    max-width: 760px;
+  }
+
+  .page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 2rem;
+    margin-bottom: 1.75rem;
+  }
+  .page-header h2 { margin: 0 0 0.25rem; }
+  .page-header p { margin: 0; font-size: 0.875rem; }
+
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1.25rem;
+  }
+  .card h3 { margin: 0 0 1rem; font-size: 1rem; font-weight: 600; }
+  .hint { font-size: 0.85rem; color: var(--text-muted); }
+  .msg-err { color: var(--danger); font-size: 0.875rem; }
+
+  .check-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  .check-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.6rem 0.75rem;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+  }
+
+  .indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+  .indicator.ok    { background: var(--success); }
+  .indicator.warn  { background: #f5a623; }
+  .indicator.error { background: var(--danger); }
+
+  .check-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    flex: 1;
+  }
+  .check-label { font-size: 0.875rem; font-weight: 500; color: var(--text); }
+  .check-detail { font-size: 0.8rem; color: var(--text-muted); }
+
+  .badge {
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    padding: 0.15rem 0.45rem;
+    border-radius: 4px;
+    flex-shrink: 0;
+  }
+  .badge.ok    { background: rgba(158,206,106,.15); color: var(--success); }
+  .badge.warn  { background: rgba(245,166,35,.15);  color: #f5a623; }
+  .badge.error { background: rgba(247,118,142,.15); color: var(--danger); }
+
+  .btn {
+    padding: 0.4rem 1rem;
+    background: var(--accent);
+    color: var(--accent-fg);
+    border: none;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: opacity .15s;
+    white-space: nowrap;
+  }
+  .btn:disabled { opacity: .4; cursor: default; }
+  .btn:not(:disabled):hover { opacity: .85; }
+</style>


### PR DESCRIPTION
## Summary

- **UI/Mojo.pm**: new `GET /api/v1/status` endpoint — runs four IMAP health checks (connectivity, authentication, watched folders, bucket→folder mappings) using `Services::IMAP::Client`
- **ui/src/lib/Status.svelte**: new Status component with colored dot indicators and ok/warn/error badges; Refresh button
- **ui/src/App.svelte**: Status tab added to nav between IMAP and Settings

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)