### PR TITLE
feat(imap): test-connection button and endpoint

### DIFF
--- a/UI/Mojo.pm
+++ b/UI/Mojo.pm
@@ -595,6 +595,51 @@ Injects the C<Services::Classifier> facade used by the child for REST calls.
         });
 
         #--------------------------------------------------------------------
+        # POST /api/v1/imap/test-connection
+        #   Body: { hostname, port, login, password, use_ssl }
+        #   Returns { ok: true } or { ok: false, error: "..." }
+        #--------------------------------------------------------------------
+        $r->post('/api/v1/imap/test-connection' => sub ($c) {
+            require Services::IMAP::Client;
+            my $body   = $c->req->json // {};
+            my $client = Services::IMAP::Client->new();
+            $client->set_configuration($self->configuration());
+            $client->set_mq($self->mq());
+            $client->set_name('imap');
+            $client->config('hostname', $body->{hostname} // '');
+            $client->config('port',     $body->{port}     // 143);
+            $client->config('login',    $body->{login}    // '');
+            $client->config('password', $body->{password} // '');
+            $client->config('use_ssl',  $body->{use_ssl}  // 0);
+            my $err = '';
+            eval {
+                unless ($client->connect()) {
+                    die 'connect';
+                }
+                unless ($client->login()) {
+                    die 'login';
+                }
+                $client->logout();
+            };
+            if ($@) {
+                if ($@ =~ /^connect/) {
+                    $err = 'Could not connect to server';
+                }
+                elsif ($@ =~ /^login/) {
+                    $err = 'Login failed';
+                }
+                elsif ($@ =~ /POPFILE-IMAP-EXCEPTION: (.+?) \(/) {
+                    $err = $1;
+                }
+                else {
+                    $err = 'Connection test failed';
+                }
+                return $c->render(json => { ok => \0, error => $err });
+            }
+            $c->render(json => { ok => \1 });
+        });
+
+        #--------------------------------------------------------------------
         # Start the daemon
         #--------------------------------------------------------------------
         my $daemon = Mojo::Server::Daemon->new(

--- a/ui/src/lib/IMAP.svelte
+++ b/ui/src/lib/IMAP.svelte
@@ -20,6 +20,9 @@
   let serverFolders = $state([]);
   let fetchingFolders = $state(false);
   let fetchError = $state('');
+  let testStatus = $state(null);
+  let testing = $state(false);
+  let saveAnyway = $state(false);
 
   let connectionReady = $derived(
     !!cfg.imap_hostname?.trim() &&
@@ -106,7 +109,25 @@
     }
   }
 
-  function markCfg() { cfgDirty = true; cfgStatus = ''; }
+  async function testConnection() {
+    testing = true;
+    testStatus = null;
+    const res = await fetch('/api/v1/imap/test-connection', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        hostname: cfg.imap_hostname,
+        port: cfg.imap_port,
+        login: cfg.imap_login,
+        password: cfg.imap_password,
+        use_ssl: cfg.imap_use_ssl ?? 0,
+      }),
+    });
+    testing = false;
+    testStatus = await res.json();
+  }
+
+  function markCfg() { cfgDirty = true; cfgStatus = ''; testStatus = null; saveAnyway = false; }
 
   onMount(load);
 </script>
@@ -159,10 +180,23 @@
     </div>
 
     <footer class="card-footer">
+      {#if testStatus?.ok}
+        <span class="msg-ok">✓ Connected</span>
+      {:else if testStatus && !testStatus.ok}
+        <span class="msg-err">✗ {testStatus.error ?? 'Connection failed'}</span>
+        <label class="save-anyway">
+          <input type="checkbox" bind:checked={saveAnyway} />
+          Save anyway
+        </label>
+      {/if}
       {#if cfgStatus === 'ok'}  <span class="msg-ok">✓ Saved</span>
       {:else if cfgStatus === 'error'}<span class="msg-err">✗ Error</span>
       {/if}
-      <button class="btn" onclick={saveCfg} disabled={!cfgDirty || saving}>
+      <button class="btn btn-secondary" onclick={testConnection} disabled={testing}>
+        {testing ? 'Testing…' : 'Test Connection'}
+      </button>
+      <button class="btn" onclick={saveCfg}
+        disabled={!cfgDirty || saving || (testStatus != null && !testStatus.ok && !saveAnyway)}>
         {saving ? 'Saving…' : 'Save Connection'}
       </button>
     </footer>
@@ -503,4 +537,18 @@
   }
   .msg-ok  { font-size: 0.82rem; color: var(--success); font-weight: 500; }
   .msg-err { font-size: 0.82rem; color: var(--danger);  font-weight: 500; }
+  .btn-secondary {
+    background: var(--bg);
+    color: var(--text);
+    border: 1px solid var(--border);
+  }
+  .btn-secondary:not(:disabled):hover { opacity: .75; }
+  .save-anyway {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.82rem;
+    color: var(--text-muted);
+    cursor: pointer;
+  }
 </style>


### PR DESCRIPTION
## Summary

- **UI/Mojo.pm**: new `POST /api/v1/imap/test-connection` — accepts connection params from the request body (without touching saved config), tests connectivity and auth, returns `{ ok: true }` or `{ ok: false, error: "..." }`
- **IMAP.svelte**: Connection card gets a "Test Connection" button, ✓/✗ status indicator, and a "Save anyway" checkbox that unblocks the Save button when a test has failed

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)