### PR TITLE
fix(ui): consistent padding for History, Corpus, Magnets tabs

### DIFF
--- a/ui/src/lib/Corpus.svelte
+++ b/ui/src/lib/Corpus.svelte
@@ -72,6 +72,8 @@
   onMount(refresh);
 </script>
 
+<div class="page">
+
 <h2>Corpus</h2>
 
 {#if status}
@@ -147,7 +149,10 @@
   {/if}
 </section>
 
+</div>
+
 <style>
+  .page { padding: 1.75rem 2rem; max-width: 760px; }
   section { margin: 1.5rem 0; }
   h3 { margin-bottom: 0.5rem; font-size: 1rem; color: var(--text-h); }
   table { border-collapse: collapse; width: 100%; }

--- a/ui/src/lib/History.svelte
+++ b/ui/src/lib/History.svelte
@@ -35,6 +35,8 @@
   $effect(() => { page; search; load(); });
 </script>
 
+<div class="page">
+
 <h2>History</h2>
 
 <div class="toolbar">
@@ -87,7 +89,10 @@
   </div>
 {/if}
 
+</div>
+
 <style>
+  .page { padding: 1.75rem 2rem; max-width: 960px; }
   .toolbar { display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem; }
   input[type=search] { padding: 0.4rem 0.6rem; border: 1px solid var(--border); border-radius: 4px; width: 280px; background: var(--bg); color: var(--text); }
   table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }

--- a/ui/src/lib/Magnets.svelte
+++ b/ui/src/lib/Magnets.svelte
@@ -44,6 +44,8 @@
   onMount(load);
 </script>
 
+<div class="page">
+
 <h2>Magnets</h2>
 
 {#if status}<p class="status">{status}</p>{/if}
@@ -88,7 +90,10 @@
   {/each}
 </section>
 
+</div>
+
 <style>
+  .page { padding: 1.75rem 2rem; max-width: 760px; }
   .row { display: flex; gap: 0.5rem; align-items: center; margin-bottom: 1rem; }
   input[type=text], select { padding: 0.35rem 0.6rem; border: 1px solid #ccc; border-radius: 4px; }
   button { padding: 0.35rem 0.8rem; border: 1px solid #ccc; border-radius: 4px; cursor: pointer; }


### PR DESCRIPTION
## Summary

Wraps History, Corpus, and Magnets in `<div class="page">` with `padding: 1.75rem 2rem` matching IMAP/Status/Settings. History uses `max-width: 960px` (wider for the table); others use `760px`.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)