### PR TITLE
feat(logger): log executed SQL to stdout

### DIFF
--- a/Classifier/Bayes.pm
+++ b/Classifier/Bayes.pm
@@ -4019,6 +4019,12 @@ method validate_sql_prepare_and_execute ($sql_or_sth, @args) {
         $execute_result = $sth->execute();
     }
 
+    if ($self->module_config('logger', 'log_sql') && $self->module_config('logger', 'log_to_stdout')) {
+        my @vals = @args;
+        (my $logged = $sth->{Statement} // '') =~ s/\?/do { my $v = shift @vals; defined $v ? "'$v'" : 'NULL' }/ge;
+        print "[SQL] $logged\n";
+    }
+
     unless ( $execute_result ) {
         my ( $package, $file, $line ) = caller;
         $self->log_msg(0, "DBI::execute failed.  Called from package '$package' ($file), line $line." );

--- a/POPFile/Logger.pm
+++ b/POPFile/Logger.pm
@@ -23,6 +23,7 @@ class POPFile::Logger :isa(POPFile::Module) {
         $self->config('format', 'default');
         $self->config('level', 0);
         $self->config('log_to_stdout', 0);
+        $self->config('log_sql', 0);
         $last_tickd = time;
         $self->mq_register('TICKD', $self);
         return 1

--- a/UI/Mojo.pm
+++ b/UI/Mojo.pm
@@ -410,6 +410,8 @@ Injects the C<Services::Classifier> facade used by the child for REST calls.
             history_archive_classes  => [history => 'archive_classes'],
             logger_level             => [logger  => 'level'],
             logger_logdir            => [logger  => 'logdir'],
+            logger_log_to_stdout     => [logger  => 'log_to_stdout'],
+            logger_log_sql           => [logger  => 'log_sql'],
             imap_enabled             => [imap    => 'enabled'],
             imap_hostname            => [imap    => 'hostname'],
             imap_port                => [imap    => 'port'],

--- a/ui/src/lib/Settings.svelte
+++ b/ui/src/lib/Settings.svelte
@@ -130,6 +130,11 @@
           desc: 'Verbosity of log output.' },
         { key: 'logger_logdir', label: 'Log Directory',  type: 'text',
           desc: 'Directory for log files. Empty = popfile root.' },
+        { key: 'logger_log_to_stdout', label: 'Log to stdout', type: 'bool',
+          desc: 'Mirror log output to stdout in addition to the log file.' },
+        { key: 'logger_log_sql', label: 'Log SQL to stdout', type: 'bool',
+          desc: 'Print every SQL statement with bound values to stdout. Only active when "Log to stdout" is also enabled.',
+          disabledWhen: (cfg) => cfg.logger_log_to_stdout != 1 },
       ],
     },
   ];
@@ -197,10 +202,11 @@
                 </div>
                 <div class="field-input">
                   {#if f.type === 'bool'}
-                    <label class="toggle">
+                    <label class="toggle" class:disabled={f.disabledWhen?.(config)}>
                       <input
                         type="checkbox"
                         checked={config[f.key] == 1}
+                        disabled={f.disabledWhen?.(config)}
                         onchange={(e) => { config[f.key] = e.target.checked ? 1 : 0; mark(); }}
                       />
                       <span class="track"></span>
@@ -404,6 +410,7 @@
   }
   .toggle input:checked + .track { background: var(--accent); }
   .toggle input:checked + .track::after { transform: translateX(20px); }
+  .toggle.disabled { opacity: 0.45; cursor: default; }
 
   /* ── Footer ── */
   .section-footer {


### PR DESCRIPTION
## Summary

- **POPFile/Logger.pm**: new `log_sql` config param (default `0`)
- **Classifier/Bayes.pm**: after `execute()` in `validate_sql_prepare_and_execute`, prints `[SQL] <statement with bound values>` to stdout when both `log_sql=1` and `log_to_stdout=1`
- **UI/Mojo.pm**: exposes `logger_log_to_stdout` and `logger_log_sql` in the config API
- **Settings.svelte**: adds both toggles to the Logging section; the SQL toggle is greyed out when `log_to_stdout` is off

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)