### PR TITLE
fix(startup): uninitialized port warning + restore optional Mojo deps (#25)

### DIFF
--- a/Proxy/Proxy.pm
+++ b/Proxy/Proxy.pm
@@ -62,6 +62,7 @@ class Proxy::Proxy :isa(POPFile::Module) {
     # ----------------------------------------------------------------------------
     method initialize {
         $self->config('enabled', 1 );
+        $self->config('port',    0 );
 
         $self->config('socks_server', '' );
         $self->config('socks_port',   1080 );

--- a/cpanfile
+++ b/cpanfile
@@ -29,6 +29,12 @@ recommends 'DBD::Pg', '0';
 # Optional: XML-RPC interface
 recommends 'SOAP::Lite', '0';
 
+# Optional Mojolicious extras (loaded via eval; missing = feature disabled, not crash)
+# CryptX: Mojo::Util encrypted cookie support
+# Future::AsyncAwait: Mojo::Base -async_await flag
+recommends 'CryptX', '0.080';
+recommends 'Future::AsyncAwait', '0.52';
+
 # Optional: Japanese language support
 recommends 'Text::Kakasi', '0';
 recommends 'Encode::Guess', '0';


### PR DESCRIPTION
## Summary
- `Proxy/Proxy.pm`: add `port=0` default in `initialize()` so start()'s log message never concatenates undef
- `cpanfile`: restore `CryptX` and `Future::AsyncAwait` as `recommends` — loaded via eval inside Mojo, absent = feature disabled, not a crash; needed so carton/cpanm includes them on fresh installs

Fixes #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)