### PR TITLE
test: integration test harness — T0 of Mojo migration (issue #189)

### DIFF
--- a/t/bayes-pipeline.t
+++ b/t/bayes-pipeline.t
@@ -1,0 +1,54 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use FindBin qw($Bin);
+use lib "$Bin/lib", "$Bin/..", "$Bin/../vendor/perl-querybuilder/lib";
+
+use Test2::V0;
+use TestHelper;
+use File::Temp qw(tempfile);
+
+my ($config, $mq, $tmpdir) = TestHelper::setup();
+my ($wm, $bayes) = TestHelper::setup_bayes($config, $mq);
+
+my $session = $bayes->get_session_key('admin', '');
+ok(defined $session && $session ne '', 'session obtained');
+
+# -----------------------------------------------------------------------
+subtest 'create buckets' => sub {
+    is($bayes->create_bucket($session, 'spam'), 1, 'spam bucket created');
+    is($bayes->create_bucket($session, 'ham'),  1, 'ham bucket created');
+    my @all = $bayes->get_all_buckets($session);
+    ok((grep { $_ eq 'spam' } @all), 'spam present in get_all_buckets');
+    ok((grep { $_ eq 'ham'  } @all), 'ham present in get_all_buckets');
+};
+
+# -----------------------------------------------------------------------
+subtest 'training and classification' => sub {
+    my ($spam_fh, $spam_file) = tempfile(DIR => $tmpdir, SUFFIX => '.eml');
+    print $spam_fh "From: attacker\@evil.com\r\nSubject: buy now cheap pills\r\n\r\nbuy cheap pills now viagra cialis\r\n";
+    close $spam_fh;
+
+    my ($ham_fh, $ham_file) = tempfile(DIR => $tmpdir, SUFFIX => '.eml');
+    print $ham_fh "From: friend\@example.com\r\nSubject: lunch today\r\n\r\nhello how are you lunch meeting today\r\n";
+    close $ham_fh;
+
+    $bayes->add_message_to_bucket($session, 'spam', $spam_file)
+        for 1..10;
+    $bayes->add_message_to_bucket($session, 'ham', $ham_file)
+        for 1..10;
+
+    ok($bayes->get_bucket_word_count($session, 'spam') > 0, 'spam has words after training');
+    ok($bayes->get_bucket_word_count($session, 'ham')  > 0, 'ham has words after training');
+
+    my $result = $bayes->classify($session, $spam_file);
+    is($result, 'spam', 'spam message classified as spam');
+};
+
+# -----------------------------------------------------------------------
+$bayes->release_session_key($session);
+
+my $stopped = eval { $bayes->stop(); 1 };
+ok($stopped, 'bayes stop completes without error');
+
+done_testing;

--- a/t/history-db.t
+++ b/t/history-db.t
@@ -1,0 +1,100 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use FindBin qw($Bin);
+use lib "$Bin/lib", "$Bin/..", "$Bin/../vendor/perl-querybuilder/lib";
+
+use Test2::V0;
+use TestHelper;
+use File::Temp qw(tempfile);
+
+my ($config, $mq, $tmpdir) = TestHelper::setup();
+
+require Services::Database;
+my $db_svc = Services::Database->new();
+TestHelper::wire($db_svc, $config, $mq);
+$db_svc->initialize();
+TestHelper::configure_db($config);
+
+require Classifier::WordMangle;
+my $wm = Classifier::WordMangle->new();
+TestHelper::wire($wm, $config, $mq);
+$wm->initialize();
+$wm->start();
+
+require Classifier::Bayes;
+my $bayes = Classifier::Bayes->new();
+TestHelper::wire($bayes, $config, $mq);
+$bayes->set_db_service($db_svc);
+$bayes->set_history(bless {}, 'TestHelper::History');
+$bayes->initialize();
+$bayes->parser()->set_mangle($wm);
+$bayes->start();
+
+require POPFile::History;
+my $history = POPFile::History->new();
+TestHelper::wire($history, $config, $mq);
+$history->set_db_service($db_svc);
+$history->set_classifier($bayes);
+$history->initialize();
+
+# -----------------------------------------------------------------------
+subtest 'history start and stop cleanly' => sub {
+    ok(lives { $history->start() }, 'history start does not die');
+    ok(lives { $history->stop()  }, 'history stop does not die');
+};
+
+# -----------------------------------------------------------------------
+subtest 'history start/stop cycle is idempotent' => sub {
+    ok(lives { $history->start() }, 'second start does not die');
+    ok(lives { $history->stop()  }, 'second stop does not die');
+};
+
+# -----------------------------------------------------------------------
+subtest 'service completes without error' => sub {
+    $history->start();
+    ok(lives { $history->service() }, 'service() does not die');
+    $history->stop();
+};
+
+# -----------------------------------------------------------------------
+subtest 'reserve_slot allocates a numeric slot and file path' => sub {
+    $history->start();
+
+    my ($slot, $file);
+    ok(lives { ($slot, $file) = $history->reserve_slot() }, 'reserve_slot does not die');
+    ok(defined $slot && $slot =~ /^\d+$/, 'slot is a positive integer');
+    ok(defined $file,                     'file path is defined');
+
+    $history->release_slot($slot);
+    $history->stop();
+};
+
+# -----------------------------------------------------------------------
+subtest 'commit_slot + service persists entry as valid slot' => sub {
+    $history->start();
+
+    my $session = $bayes->get_session_key('admin', '');
+    $bayes->create_bucket($session, 'inbox');
+
+    my ($slot, $file) = $history->reserve_slot();
+
+    open my $fh, '>', $file
+        or die "Cannot write slot file: $!";
+    print $fh "From: sender\@example.com\r\nSubject: test\r\nDate: Mon, 1 Jan 2024 00:00:00 +0000\r\n\r\nBody\r\n";
+    close $fh;
+
+    $history->commit_slot($session, $slot, 'inbox', '');
+    $history->service();
+
+    ok($history->is_valid_slot($slot), 'slot appears in history after commit');
+
+    $bayes->release_session_key($session);
+    $history->stop();
+};
+
+# -----------------------------------------------------------------------
+$bayes->stop();
+$db_svc->stop();
+
+done_testing;

--- a/t/mojo-app-integration.t
+++ b/t/mojo-app-integration.t
@@ -1,0 +1,109 @@
+#!/usr/bin/perl
+BEGIN {
+    @INC = grep { !/\/lib$/ && $_ ne 'lib' && !/thread-multi/ } @INC;
+    require FindBin;
+    require Cwd;
+    my $root = Cwd::abs_path("$FindBin::Bin/..");
+    require lib;
+    lib->import("$root/local/lib/perl5");
+    unshift @INC, "$FindBin::Bin/lib", $root;
+}
+use strict;
+use warnings;
+
+use Test2::V0;
+use Test::Mojo;
+use TestHelper;
+
+my ($config, $mq, $tmpdir) = TestHelper::setup();
+
+require Services::Database;
+my $db_svc = Services::Database->new();
+TestHelper::wire($db_svc, $config, $mq);
+$db_svc->initialize();
+TestHelper::configure_db($config);
+
+require Classifier::WordMangle;
+my $wm = Classifier::WordMangle->new();
+TestHelper::wire($wm, $config, $mq);
+$wm->initialize();
+$wm->start();
+
+require Classifier::Bayes;
+my $bayes = Classifier::Bayes->new();
+TestHelper::wire($bayes, $config, $mq);
+$bayes->set_db_service($db_svc);
+$bayes->set_history(bless {}, 'TestHelper::History');
+$bayes->initialize();
+$bayes->parser()->set_mangle($wm);
+$bayes->start();
+
+require Services::Classifier;
+my $svc = Services::Classifier->new();
+TestHelper::wire($svc, $config, $mq);
+$svc->set_classifier($bayes);
+$svc->initialize();
+$svc->start();
+
+require POPFile::API;
+my $api = POPFile::API->new();
+TestHelper::wire($api, $config, $mq);
+$api->initialize();
+
+my $app = $api->build_app($svc, $svc->session());
+$app->log->level('fatal');
+my $t = Test::Mojo->new($app);
+
+# -----------------------------------------------------------------------
+subtest 'GET /api/v1/buckets returns JSON array' => sub {
+    $t->get_ok('/api/v1/buckets')
+      ->status_is(200);
+    ok(ref $t->tx->res->json eq 'ARRAY', 'response is a JSON array');
+};
+
+# -----------------------------------------------------------------------
+subtest 'POST /api/v1/buckets creates a bucket' => sub {
+    $t->post_ok('/api/v1/buckets', json => { name => 'spam' })
+      ->status_is(200)
+      ->json_is('/ok', 1);
+};
+
+# -----------------------------------------------------------------------
+subtest 'GET /api/v1/buckets contains newly created bucket' => sub {
+    $t->get_ok('/api/v1/buckets')
+      ->status_is(200);
+    my $list = $t->tx->res->json;
+    ok((grep { $_->{name} eq 'spam' } @$list), 'spam bucket appears in list');
+};
+
+# -----------------------------------------------------------------------
+subtest 'GET /api/v1/status returns 200' => sub {
+    $t->get_ok('/api/v1/status')
+      ->status_is(200);
+};
+
+# -----------------------------------------------------------------------
+subtest 'GET /api/v1/config has mojo_ui_locale key' => sub {
+    $t->get_ok('/api/v1/config')
+      ->status_is(200)
+      ->json_has('/mojo_ui_locale');
+};
+
+# -----------------------------------------------------------------------
+subtest 'DELETE /api/v1/buckets/:name removes the bucket' => sub {
+    $t->delete_ok('/api/v1/buckets/spam')
+      ->status_is(200)
+      ->json_is('/ok', 1);
+
+    $t->get_ok('/api/v1/buckets')
+      ->status_is(200);
+    my $list = $t->tx->res->json;
+    ok(!(grep { $_->{name} eq 'spam' } @$list), 'spam no longer in bucket list');
+};
+
+# -----------------------------------------------------------------------
+$svc->stop();
+$bayes->stop();
+$db_svc->stop();
+
+done_testing;


### PR DESCRIPTION
## Summary

- `t/bayes-pipeline.t`: full Bayes lifecycle against real SQLite — create bucket, train 10× with inline temp messages, classify, verify word count, stop
- `t/history-db.t`: POPFile::History write/read against real SQLite — lazy db init, reserve_slot, commit_slot+service flush, is_valid_slot verification
- `t/mojo-app-integration.t`: REST API backed by real Classifier + real SQLite — GET/POST/DELETE /api/v1/buckets, GET /api/v1/config, GET /api/v1/status

No production `.pm` files changed. All 173 tests green.

## Test plan

- [ ] `carton exec prove -l t/bayes-pipeline.t` passes
- [ ] `carton exec prove -l t/history-db.t` passes
- [ ] `carton exec prove -l t/mojo-app-integration.t` passes
- [ ] `carton exec prove -l t/` — all 173 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)