### PR TITLE
fix: respect api_local when binding the HTTP server

### DIFF
--- a/POPFile/API.pm
+++ b/POPFile/API.pm
@@ -68,12 +68,15 @@ starts it. Returns 1 on success.
 
 method _find_free_port() {
     require IO::Socket::INET;
-    my $sock = IO::Socket::INET->new(
+    my %socket_args = (
         Listen => 1,
         Proto => 'tcp',
-        LocalAddr => '0.0.0.0',
         LocalPort => 0,
         ReuseAddr => 1 );
+    $socket_args{LocalAddr} = '127.0.0.1'
+        if $self->config('local');
+    my $sock = IO::Socket::INET->new(
+        %socket_args );
     my $port = $sock->sockport();
     $sock->close();
     return $port
@@ -99,9 +102,12 @@ method start() {
         }
     }
     my $app = $self->build_app($service, undef);
+    my $host = $self->config('local')
+        ? '127.0.0.1'
+        : '*';
     my $daemon = Mojo::Server::Daemon->new(
         app => $app,
-        listen => ["http://*:$port"] );
+        listen => ["http://$host:$port"] );
     $daemon->start();
     $daemon_ref = $daemon;
     $self->log_msg(0, "POPFile::API: listening on port $port");

--- a/t/api-no-fork.t
+++ b/t/api-no-fork.t
@@ -24,6 +24,26 @@ TestHelper::wire($api, $config, $mq);
 $api->initialize();
 $api->set_service($svc);
 
+sub with_stubbed_daemon {
+    my ($code) = @_;
+    my $listen;
+    no warnings 'once';
+    no warnings 'redefine';
+    local *POPFile::API::_find_free_port = sub { 43123 };
+    local *Mojo::Server::Daemon::new = sub {
+        my ($class, %args) = @_;
+        $listen = $args{listen};
+        return bless {
+            app => $args{app},
+            listen => $args{listen},
+        }, $class;
+    };
+    local *Mojo::Server::Daemon::start = sub { return 1 };
+    local *Mojo::Server::Daemon::stop = sub { return 1 };
+    local *Mojo::Server::Daemon::listen = sub { return $_[0]->{listen} };
+    return $code->(\$listen);
+}
+
 subtest 'run_server removed from POPFile::API' => sub {
     ok(!POPFile::API->can('run_server'), 'run_server() has been removed');
 };
@@ -34,13 +54,32 @@ subtest 'forked override removed from Services::Classifier' => sub {
 };
 
 subtest 'start() registers in-process Mojo daemon without fork' => sub {
-    $api->start();
-    ok($api->can('daemon') && defined $api->daemon(),
-        'daemon is set up in-process after start()');
-    if ($api->can('daemon') && defined $api->daemon()) {
-        isa_ok($api->daemon(), 'Mojo::Server::Daemon');
-    }
-    $api->stop();
+    with_stubbed_daemon(sub {
+        my ($listen) = @_;
+        $api->start();
+        ok($api->can('daemon') && defined $api->daemon(),
+            'daemon is set up in-process after start()');
+        if ($api->can('daemon') && defined $api->daemon()) {
+            isa_ok($api->daemon(), 'Mojo::Server::Daemon');
+            is($$listen->[0], 'http://127.0.0.1:43123',
+                'default api_local=1 binds to loopback');
+            is($config->parameter('api_port'), 43123,
+                'selected port is persisted to config');
+        }
+        $api->stop();
+    });
+};
+
+subtest 'api_local=0 binds the API to all interfaces' => sub {
+    with_stubbed_daemon(sub {
+        my ($listen) = @_;
+        $config->parameter('api_local', 0);
+        $config->parameter('api_port', 0);
+        $api->start();
+        is($$listen->[0], 'http://*:43123',
+            'api_local=0 binds to all interfaces');
+        $api->stop();
+    });
 };
 
 $svc->stop();


### PR DESCRIPTION
## Summary
- respect api_local when choosing the API bind address
- use loopback-only free-port allocation when api_local=1
- cover both bind modes in t/api-no-fork.t

Closes #239.

## Testing
- carton exec prove -l t/api-no-fork.t t/00-load.t