### PR TITLE
fix: isolate IMAP test-connection config from runtime state

### DIFF
--- a/POPFile/API/Controller/IMAP.pm
+++ b/POPFile/API/Controller/IMAP.pm
@@ -18,6 +18,31 @@ L<POPFile::API/build_app>: C<popfile_api> for configuration access.
 use Mojo::Base 'Mojolicious::Controller', -signatures;
 use POPFile::Features;
 
+sub _make_test_client($self, $body) {
+    require POPFile::Configuration;
+    require Services::IMAP::Client;
+    my $api = $self->popfile_api;
+    my $base = $api->configuration();
+    my $config = POPFile::Configuration->new();
+    $config->set_configuration($config);
+    $config->set_mq($api->mq());
+    $config->set_popfile_root($base->popfile_root());
+    $config->set_popfile_user($base->popfile_user());
+    $config->initialize();
+    $config->set_started(1);
+    $config->parameter('GLOBAL_timeout', $base->parameter('GLOBAL_timeout') // 60);
+    my $client = Services::IMAP::Client->new();
+    $client->set_configuration($config);
+    $client->set_mq($api->mq());
+    $client->set_name('imap');
+    $client->config('hostname', $body->{hostname} // '');
+    $client->config('port', $body->{port} // 143);
+    $client->config('login', $body->{login} // '');
+    $client->config('password', $body->{password} // '');
+    $client->config('use_ssl', $body->{use_ssl} // 0);
+    return $client
+}
+
 sub get_folders ($self) {
     my $api = $self->popfile_api;
     my $watched_raw = $api->module_config('imap', 'watched_folders') // '';
@@ -71,18 +96,8 @@ sub get_server_folders ($self) {
 }
 
 sub test_connection ($self) {
-    require Services::IMAP::Client;
-    my $api = $self->popfile_api;
     my $body = $self->req->json // {};
-    my $client = Services::IMAP::Client->new();
-    $client->set_configuration($api->configuration());
-    $client->set_mq($api->mq());
-    $client->set_name('imap');
-    $client->config('hostname', $body->{hostname} // '');
-    $client->config('port', $body->{port} // 143);
-    $client->config('login', $body->{login} // '');
-    $client->config('password', $body->{password} // '');
-    $client->config('use_ssl', $body->{use_ssl} // 0);
+    my $client = $self->_make_test_client($body);
     my $err = '';
     try {
         unless ($client->connect()) {

--- a/t/mojo-imap.t
+++ b/t/mojo-imap.t
@@ -1,0 +1,65 @@
+#!/usr/bin/perl
+BEGIN {
+    @INC = grep { !/\/lib$/ && $_ ne 'lib' && !/thread-multi/ } @INC;
+    require FindBin;
+    require Cwd;
+    my $root = Cwd::abs_path("$FindBin::Bin/..");
+    require lib;
+    lib->import("$root/local/lib/perl5");
+    unshift @INC, "$FindBin::Bin/lib", $root;
+}
+use strict;
+use warnings;
+
+use Test2::V0;
+use TestHelper;
+
+my ($config, $mq, $tmpdir) = TestHelper::setup();
+
+require POPFile::API;
+require POPFile::API::Controller::IMAP;
+
+my $api = POPFile::API->new();
+TestHelper::wire($api, $config, $mq);
+$api->initialize();
+
+subtest '_make_test_client uses request values without mutating live imap config' => sub {
+    $config->parameter('imap_hostname', 'live.example');
+    $config->parameter('imap_port', 993);
+    $config->parameter('imap_login', 'live-user');
+    $config->parameter('imap_password', 'live-pass');
+    $config->parameter('imap_use_ssl', 1);
+    $config->parameter('GLOBAL_timeout', 75);
+
+    my $controller = bless { api => $api }, 'POPFile::API::Controller::IMAP';
+
+    no warnings 'once';
+    no warnings 'redefine';
+    local *POPFile::API::Controller::IMAP::popfile_api = sub {
+        my ($self) = @_;
+        return $self->{api};
+    };
+
+    my $client = $controller->_make_test_client({
+        hostname => 'test.example',
+        port => 143,
+        login => 'test-user',
+        password => 'test-pass',
+        use_ssl => 0,
+    });
+
+    is($client->config('hostname'), 'test.example', 'test client hostname comes from request');
+    is($client->config('port'), 143, 'test client port comes from request');
+    is($client->config('login'), 'test-user', 'test client login comes from request');
+    is($client->config('password'), 'test-pass', 'test client password comes from request');
+    is($client->config('use_ssl'), 0, 'test client ssl flag comes from request');
+    is($client->global_config('timeout'), 75, 'test client inherits global timeout');
+
+    is($config->parameter('imap_hostname'), 'live.example', 'hostname left unchanged');
+    is($config->parameter('imap_port'), 993, 'port left unchanged');
+    is($config->parameter('imap_login'), 'live-user', 'login left unchanged');
+    is($config->parameter('imap_password'), 'live-pass', 'password left unchanged');
+    is($config->parameter('imap_use_ssl'), 1, 'ssl flag left unchanged');
+};
+
+done_testing;


### PR DESCRIPTION
## Summary
- build a temporary configuration for the IMAP connection test client
- keep submitted test credentials isolated from the live runtime `imap_*` settings
- add a regression test that proves request values are used without mutating runtime config

Closes #238.

## Testing
- `carton exec prove -l t/mojo-imap.t t/00-load.t`
