### PR TITLE
fix(imap): move uid state from config to DB, fix pending folder moves

### DIFF
--- a/Classifier/popfile.sql
+++ b/Classifier/popfile.sql
@@ -1,4 +1,4 @@
--- POPFILE SCHEMA 3
+-- POPFILE SCHEMA 4
 -- ---------------------------------------------------------------------------
 --
 -- popfile.schema - POPFile's database schema
@@ -399,11 +399,25 @@ create trigger delete_bucket_template delete on bucket_template
                  delete from bucket_params where btid = old.id;
              end;
 
+-- ---------------------------------------------------------------------------
+--
+-- imap_folder_state - persists IMAP UIDNEXT and UIDVALIDITY per folder so
+--                     that this state survives config resets.
+--
+-- ---------------------------------------------------------------------------
+
+create table imap_folder_state (
+    id integer primary key,
+    folder varchar(255) unique not null,
+    uid_next integer,
+    uid_validity integer
+);
+
 -- Default data
 
--- This is schema version 3
+-- This is schema version 4
 
-insert into popfile ( version ) values ( 3 );
+insert into popfile ( version ) values ( 4 );
 
 -- There's always a user called 'admin'
 

--- a/Services/IMAP.pm
+++ b/Services/IMAP.pm
@@ -47,6 +47,7 @@ field $poll_running = 0;
 field $poll_started_at = 0;
 field @pending_train_flags;
 field @pending_train_buckets;
+field %_uid_next_override;
 
 my $cfg_separator = "-->";
 
@@ -58,8 +59,8 @@ BUILD {
 
 Registers all IMAP configuration parameters with their defaults: C<hostname>,
 C<port> (143), C<login>, C<password>, C<update_interval> (20 s), C<expunge>,
-C<use_ssl>, C<watched_folders>, C<bucket_folder_mappings>, C<uidvalidities>,
-C<uidnexts>, C<enabled> (0), C<training_mode> (0).  Returns 1.
+C<use_ssl>, C<watched_folders>, C<bucket_folder_mappings>,
+C<enabled> (0), C<training_mode> (0).  Returns 1.
 
 =cut
 
@@ -73,8 +74,6 @@ method initialize() {
     $self->config('use_ssl', 0);
     $self->config('watched_folders', 'INBOX');
     $self->config('bucket_folder_mappings', '');
-    $self->config('uidvalidities', '');
-    $self->config('uidnexts', '');
     $self->config('enabled', 0);
     $self->config('training_mode', 0);
     $self->config('training_error', '');
@@ -181,12 +180,6 @@ method poll() {
                     $self->config('training_mode', 0);
                 }
             }
-            if (defined $result->{uid_nexts_str}) {
-                $self->config('uidnexts', $result->{uid_nexts_str});
-            }
-            if (defined $result->{uid_validities_str}) {
-                $self->config('uidvalidities', $result->{uid_validities_str});
-            }
             if ($result->{training_done}) {
                 unlink @pending_train_flags;
                 @pending_train_flags = ();
@@ -199,7 +192,14 @@ method poll() {
 }
 
 method _run_poll_work() {
-    my $result = { trained => 0, uid_nexts_str => undef, uid_validities_str => undef, training_done => 0, error => undef };
+    my $result = { trained => 0, training_done => 0, error => undef };
+    my $dbh;
+    try {
+        $dbh = $self->_open_uid_db();
+    }
+    catch ($e) {
+        $self->log_msg(0, "Could not open uid state DB: $e");
+    }
     try {
         local $SIG{PIPE} = 'IGNORE';
         local $SIG{__DIE__};
@@ -208,19 +208,23 @@ method _run_poll_work() {
             $result->{training_done} = 1;
         }
         else {
+            my ($nexts, $validities) = defined $dbh
+                ? $self->_load_uid_state($dbh)
+                : ({}, {});
             if (!%folders || $folder_change_flag == 1) {
                 $self->build_folder_list();
             }
-            $self->connect_server();
+            $self->connect_server(nexts => $nexts, validities => $validities);
             %hash_values = ();
             for my $folder (keys %folders) {
-                next unless exists $folders{$folder}{watched};
-                $self->scan_folder($folder)
-                    if exists $folders{$folder}{imap};
+                next unless exists $folders{$folder}{imap};
+                $self->scan_folder($folder);
             }
+            my ($any_imap) = map { $_->{imap} }
+                grep { defined $_->{imap} } values %folders;
+            $self->_save_uid_state($dbh, $any_imap)
+                if defined $dbh && defined $any_imap;
         }
-        $result->{uid_nexts_str} = $self->config('uidnexts');
-        $result->{uid_validities_str} = $self->config('uidvalidities');
     }
     catch ($err) {
         $self->disconnect_folders();
@@ -232,6 +236,7 @@ method _run_poll_work() {
             $result->{training_done} = -1;
         }
     }
+    $dbh->disconnect() if defined $dbh;
     return $result
 }
 
@@ -247,19 +252,102 @@ method api_session() {
     return $api_session
 }
 
-=head2 new_imap_client()
+=head2 _db_path()
 
-Creates, configures, and connects a new L<Services::IMAP::Client> instance.
-Returns the connected client on success, or C<undef> and sets C<$imap_error>
-on failure.
+Returns the full filesystem path of the POPFile SQLite database.
 
 =cut
 
-method new_imap_client() {
+method _db_path() {
+    $self->get_user_path($self->module_config('bayes', 'database'))
+}
+
+=head2 _open_uid_db()
+
+Opens a fresh, self-contained DBI connection to the SQLite database for
+reading and writing C<imap_folder_state>.  The caller is responsible for
+calling C<disconnect()> when done.  Safe to call in forked subprocesses.
+
+=cut
+
+method _open_uid_db() {
+    require DBI;
+    return DBI->connect(
+        'dbi:SQLite:dbname=' . $self->_db_path(), '', '',
+        { RaiseError => 1, PrintError => 0, AutoCommit => 1 })
+}
+
+=head2 _load_uid_state($dbh)
+
+Reads all rows from C<imap_folder_state> and returns two hash-refs:
+C<\%uid_nexts> and C<\%uid_validities>, keyed by folder name.
+
+=cut
+
+method _load_uid_state($dbh) {
+    my (%nexts, %validities);
+    my $rows = $dbh->selectall_arrayref(
+        'SELECT folder, uid_next, uid_validity FROM imap_folder_state',
+        { Slice => {} });
+    for my $row ($rows->@*) {
+        $nexts{$row->{folder}} = $row->{uid_next}
+            if defined $row->{uid_next};
+        $validities{$row->{folder}} = $row->{uid_validity}
+            if defined $row->{uid_validity};
+    }
+    for my $folder (keys %_uid_next_override) {
+        $nexts{$folder} = $_uid_next_override{$folder};
+    }
+    return \%nexts, \%validities
+}
+
+=head2 _save_uid_state($dbh, $imap)
+
+Reads uid_next and uid_validity from C<$imap> (a L<Services::IMAP::Client>)
+and upserts them into C<imap_folder_state>.
+
+=cut
+
+method _save_uid_state($dbh, $imap) {
+    my $nexts = $imap->uid_nexts();
+    my $validities = $imap->uid_validities();
+    for my $folder (keys %$nexts) {
+        $dbh->do(
+            'INSERT OR REPLACE INTO imap_folder_state (folder, uid_next, uid_validity) VALUES (?,?,?)',
+            undef, $folder, $nexts->{$folder}, $validities->{$folder});
+    }
+    %_uid_next_override = ();
+}
+
+=head2 _reset_uid_next($folder)
+
+Registers an override that forces the next poll to scan C<$folder> from the
+beginning (uid_next = 1).  Used when a UI reclassification request arrives
+for a message that may be below the current C<uid_next> watermark.
+
+=cut
+
+method _reset_uid_next($folder) {
+    $self->log_msg(1, "Scheduling uid_next reset for folder $folder to force re-scan.");
+    $_uid_next_override{$folder} = 1;
+}
+
+=head2 new_imap_client()
+
+Creates, configures, and connects a new L<Services::IMAP::Client> instance,
+pre-seeding it with uid state loaded from the database.  Returns the
+connected client on success, or C<undef> and sets C<$imap_error> on failure.
+
+=cut
+
+method new_imap_client(%args) {
     my $client = Services::IMAP::Client->new();
     $client->set_configuration($self->configuration());
     $client->set_mq($self->mq());
     $client->set_name($self->name());
+    if (defined $args{nexts}) {
+        $client->load_uid_state(nexts => $args{nexts}, validities => $args{validities});
+    }
     if ($client->connect()) {
         if ($client->login()) {
             return $client
@@ -294,17 +382,18 @@ method build_folder_list() {
     $folder_change_flag = 0;
 }
 
-=head2 connect_server()
+=head2 connect_server(%uid_state)
 
 Opens IMAP connections for all folders in C<%folders> that do not yet have
 one.  For each folder it verifies (or creates) the folder on the server,
 retrieves C<UIDVALIDITY> and C<UIDNEXT>, and persists those values via the
-client.  Dies with a C<POPFILE-IMAP-EXCEPTION> if a connection cannot be
-established.
+client.  C<%uid_state> may contain C<nexts> and C<validities> hash-refs for
+pre-loading uid state into the client.  Dies with a C<POPFILE-IMAP-EXCEPTION>
+if a connection cannot be established.
 
 =cut
 
-method connect_server() {
+method connect_server(%uid_state) {
     my $imap;
     for my $folder (keys %folders) {
         next if exists $folders{$folder}{imap};
@@ -314,7 +403,7 @@ method connect_server() {
             next;
         }
         unless (defined $imap) {
-            $imap = $self->new_imap_client()
+            $imap = $self->new_imap_client(%uid_state)
                 or die "POPFILE-IMAP-EXCEPTION: Could not connect: $imap_error " . __FILE__ . '(' . __LINE__ . '))';
         }
         @mailboxes = $imap->get_mailbox_list() unless @mailboxes;
@@ -374,14 +463,26 @@ method disconnect_folders() {
 
 =head2 request_folder_move($hash, $target_bucket)
 
-Queues a folder move for the message identified by C<$hash>.  On the next
-IMAP scan cycle the message will be moved to the folder mapped to
-C<$target_bucket>.
+Queues a folder move for the message identified by C<$hash>.  Also resets
+C<uid_next> for the message's current folder so the next poll re-scans from
+the beginning of that folder and can find the message regardless of where
+C<uid_next> currently stands.
 
 =cut
 
 method request_folder_move ($hash, $target_bucket) {
     $pending_folder_moves{$hash} = $target_bucket;
+    $self->_reset_uid_next($_) for $self->watched_folders();
+    return unless ref $history;
+    my $slot = $history->get_slot_from_hash($hash);
+    return if $slot eq '';
+    my @fields = $history->get_slot_fields($slot);
+    my $current_bucket = $fields[8];
+    my $current_folder = defined $current_bucket
+        ? $self->folder_for_bucket($current_bucket)
+        : undef;
+    $self->_reset_uid_next($current_folder)
+        if defined $current_folder;
 }
 
 =head2 scan_folder($folder)
@@ -446,7 +547,7 @@ method scan_folder ($folder) {
             if (my $old_bucket = $self->can_reclassify($hash, $bucket)) {
                 $self->reclassify_message($folder, $msg, $old_bucket, $hash);
             }
-            else {
+            elsif (!ref $history || $history->get_slot_from_hash($hash) eq '') {
                 $self->insert_message_into_bucket($folder, $msg, $bucket);
             }
             next;

--- a/Services/IMAP/Client.pm
+++ b/Services/IMAP/Client.pm
@@ -39,9 +39,10 @@ field $folder = undef;
 field $tag = 0;
 field $last_response = '';
 field $last_command = '';
+field %_uid_next;
+field %_uid_validity;
 
 my $eol = "\015\012";
-my $cfg_separator = "-->";
 
 method _imap_utf7_decode($chunk) {
     return '&'
@@ -447,55 +448,69 @@ method fetch_message_part ($msg, $part) {
     return 1, @lines
 }
 
+=head2 load_uid_state(%nexts, %validities)
+
+Pre-loads in-memory UID state from the caller (typically after reading from
+the database).  Both arguments are plain hashes keyed by folder name.
+
+=cut
+
+method load_uid_state (%args) {
+    %_uid_next = $args{nexts}->%*
+        if ref $args{nexts} eq 'HASH';
+    %_uid_validity = $args{validities}->%*
+        if ref $args{validities} eq 'HASH';
+}
+
+=head2 uid_nexts() / uid_validities()
+
+Return references to the in-memory uid_next / uid_validity hashes so that
+the caller can persist the current state to the database.
+
+=cut
+
+method uid_nexts ()     { \%_uid_next }
+method uid_validities () { \%_uid_validity }
+
 =head2 uid_validity($folder_name, $uidval)
 
-Get/set the persisted C<UIDVALIDITY> for C<$folder_name>.  With one argument,
+Get/set the in-memory C<UIDVALIDITY> for C<$folder_name>.  With one argument,
 returns the stored value or C<undef>.  With two arguments, stores the new
-value in config and returns nothing.
+value and returns nothing.
 
 =cut
 
 method uid_validity ($folder_name, $uidval = undef) {
     Carp::confess("gimme a folder!") unless $folder_name;
-    my $all = $self->config('uidvalidities');
-    my %hash = defined $all ? split(/$cfg_separator/, $all) : ();
     if (defined $uidval) {
-        $hash{$folder_name} = $uidval;
-        my $new = '';
-        $new .= "$_$cfg_separator$hash{$_}$cfg_separator" for keys %hash;
-        $self->config('uidvalidities', $new);
+        $_uid_validity{$folder_name} = $uidval;
         $self->log_msg(1, "Updated UIDVALIDITY value for folder $folder_name to $uidval.");
         return
     }
     return undef
-        unless defined $hash{$folder_name};
-    return $hash{$folder_name} =~ /^\d+$/
-        ? $hash{$folder_name}
+        unless exists $_uid_validity{$folder_name};
+    return $_uid_validity{$folder_name} =~ /^\d+$/
+        ? $_uid_validity{$folder_name}
         : undef
 }
 
 =head2 uid_next($folder_name, $uidnext)
 
-Get/set the persisted C<UIDNEXT> for C<$folder_name>.  With one argument,
+Get/set the in-memory C<UIDNEXT> for C<$folder_name>.  With one argument,
 returns the stored value or C<undef>.  With two arguments, stores the new
-value in config and returns nothing.
+value and returns nothing.
 
 =cut
 
 method uid_next ($folder_name, $uidnext = undef) {
     Carp::confess("I need a folder") unless $folder_name;
-    my $all = $self->config('uidnexts');
-    my %hash = defined $all ? split(/$cfg_separator/, $all) : ();
     if (defined $uidnext) {
-        $hash{$folder_name} = $uidnext;
-        my $new = '';
-        $new .= "$_$cfg_separator$hash{$_}$cfg_separator" for keys %hash;
-        $self->config('uidnexts', $new);
+        $_uid_next{$folder_name} = $uidnext;
         $self->log_msg(1, "Updated UIDNEXT value for folder $folder_name to $uidnext.");
         return
     }
-    return exists $hash{$folder_name} && $hash{$folder_name} =~ /^\d+$/
-        ? $hash{$folder_name}
+    return exists $_uid_next{$folder_name} && $_uid_next{$folder_name} =~ /^\d+$/
+        ? $_uid_next{$folder_name}
         : undef
 }
 

--- a/t/imap-folder-moves.t
+++ b/t/imap-folder-moves.t
@@ -1,0 +1,102 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use FindBin qw($Bin);
+use lib "$Bin/lib", "$Bin/..", "$Bin/../vendor/perl-querybuilder/lib";
+
+use Test2::V0;
+use Log::Any::Test;
+use Log::Any qw($log);
+use TestHelper;
+
+require Services::IMAP;
+
+{
+    package StubClassifier;
+    sub new              { bless {}, shift }
+    sub get_session_key  { 'session' }
+    sub get_all_buckets  { ('work') }
+    sub is_pseudo_bucket { 0 }
+}
+
+{
+    package StubHistory;
+    sub new { bless {}, shift }
+    sub get_slot_from_hash { 'slot1' }
+    sub get_slot_fields    { (undef) x 8, 'work' }
+    sub get_message_hash   { 'deadbeef' }
+    sub commit_history     {}
+}
+
+{
+    package StubIMAPClient;
+    sub new { bless { uv => {}, un => {} }, shift }
+    sub connected                       { 1 }
+    sub get_mailbox_list                { () }
+    sub status                          { { UIDNEXT => 10, UIDVALIDITY => 1 } }
+    sub create_folder                   {}
+    sub uid_validity                    { my ($s,$f,$v) = @_; $s->{uv}{$f} = $v if defined $v; $s->{uv}{$f} }
+    sub uid_next                        { my ($s,$f,$v) = @_; $s->{un}{$f} = $v if defined $v; $s->{un}{$f} }
+    sub uid_nexts                       { {} }
+    sub uid_validities                  { {} }
+    sub check_uidvalidity               { 1 }
+    sub load_uid_state                  {}
+    sub noop                            {}
+    sub logout                          {}
+    sub expunge                         {}
+    sub get_new_message_list_unselected { () }
+}
+
+sub make_imap {
+    my ($config, $mq) = TestHelper::setup();
+    my $imap = Services::IMAP->new();
+    TestHelper::wire($imap, $config, $mq);
+    $imap->initialize();
+    $imap->set_classifier(StubClassifier->new());
+    $imap->set_history(StubHistory->new());
+    $config->parameter('imap_enabled', 1);
+    $config->parameter('imap_training_mode', 0);
+    $config->parameter('imap_update_interval', 20);
+    $config->parameter('imap_watched_folders', 'INBOX-->');
+    $config->parameter('imap_bucket_folder_mappings', 'work-->Work-->');
+    return ($imap, $config)
+}
+
+subtest 'request_folder_move schedules uid_next reset for watched folder' => sub {
+    my ($imap) = make_imap();
+    $log->clear();
+
+    $imap->request_folder_move('deadbeef', 'work');
+
+    my @reset_msgs = grep { /Scheduling uid_next reset/ } map { $_->{message} } @{ $log->msgs() };
+    ok(scalar @reset_msgs >= 1, 'uid_next reset scheduled for at least one folder');
+};
+
+subtest 'request_folder_move resets output folder when message is in history' => sub {
+    my ($imap) = make_imap();
+    $log->clear();
+
+    $imap->request_folder_move('deadbeef', 'personal');
+
+    my @reset_msgs = grep { /Scheduling uid_next reset/ } map { $_->{message} } @{ $log->msgs() };
+    my $reset_for_work = grep { /Work/ } @reset_msgs;
+    ok($reset_for_work >= 1, 'uid_next reset scheduled for output folder Work');
+};
+
+subtest 'output folder is scanned for pending_folder_moves' => sub {
+    my ($imap, $config) = make_imap();
+    my $stub = StubIMAPClient->new();
+    my @scanned;
+    no warnings 'redefine';
+    local *Services::IMAP::new_imap_client  = sub { $stub };
+    local *Services::IMAP::scan_folder      = sub { push @scanned, $_[1] };
+
+    $imap->_run_poll_work();
+
+    my $inbox_scanned = grep { $_ eq 'INBOX' } @scanned;
+    my $work_scanned  = grep { $_ eq 'Work'  } @scanned;
+    ok($inbox_scanned, 'watched folder INBOX was scanned');
+    ok($work_scanned,  'output folder Work was scanned');
+};
+
+done_testing;


### PR DESCRIPTION
## Summary

Fixes #245 and the immediately reported bug where UI reclassifications are never applied to IMAP folders.

### Root cause

Two interlocked bugs:

1. **`imap_uidnexts` / `imap_uidvalidities` persisted in `popfile.cfg`** — the IMAP scan position was lost on every config reset, causing all inbox messages to be permanently skipped.

2. **`pending_folder_moves` was dead code for already-classified messages** — the mechanism requires a message to appear above `uid_next` in a scanned folder. After IMAP classifies and moves a message to an output folder, `uid_next` advances past it. The message is never seen again, so the pending move never fires.

### Changes

- **Schema v4**: adds `imap_folder_state(folder, uid_next, uid_validity)` table. The automatic `db_upgrade` path handles existing databases.
- **`Services::IMAP::Client`**: `uid_next()` and `uid_validity()` now use in-memory hashes instead of config. New `load_uid_state()` / `uid_nexts()` / `uid_validities()` methods for bulk transfer.
- **`Services::IMAP`**: loads/saves uid state from the DB via a fresh subprocess-safe DBI connection. Removes `uidnexts` / `uidvalidities` config parameters entirely.
- **Output folder scanning**: the scan loop now covers all folders (watched + output), not only watched ones. The `can_reclassify` / history check prevents double-training of already-correctly-classified messages.
- **`request_folder_move()`**: resets `uid_next = 1` for the relevant folder(s) before the next poll, forcing a re-scan from the beginning so the target message is found regardless of current watermark.

## Test plan

- [ ] `carton exec prove -l t/` — all 241 tests pass
- [ ] `t/imap-folder-moves.t` — 3 new subtests covering uid-next reset and output folder scanning
- [ ] Start POPFile, reclassify a message via the web UI, verify it moves to the correct IMAP folder on the next poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)